### PR TITLE
Updated README for example authlogic app to include Rails 3 instructions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,6 +36,19 @@ Now add the gem dependency in your config:
 Or you install this as a plugin (for older versions of rails)
 
   script/plugin install git://github.com/binarylogic/authlogic.git
+  
+For Rails 3 and bundler, add this to your Gemfile:
+  
+  # odorcicd provides a fork of this project for Rails 3
+  gem "authlogic", :git => "git://github.com/odorcicd/authlogic.git", :branch => "rails3"
+  
+Install the gem with bundler:
+
+  $ bundle install
+
+For the Rails 3 version as a plugin:
+
+  $ rails plugin install git://github.com/odorcicd/authlogic.git -r rails3
 
 === 2. Create your UserSession model
 
@@ -54,11 +67,21 @@ This will create a file that looks like:
     # configuration here, see documentation for sub modules of Authlogic::Session
   end
 
+The generator script doesn't work in Rails 3, so if that's your Rails version create a new model the standard way:
+
+  $ rails generate model user_session
+
+Then edit the new model manually to inherit from Authlogic::Session::Base as above
+
 === 3. Ensure proper database fields
 
 If you don't already have a User model, go ahead and create one:
 
-  script/generate model user
+  $ script/generate model user
+
+For Rails 3 this looks like:
+
+  $ rails generate model user
 
 Since you are authenticating with your User model, it can have the following columns. The names of these columns can be changed with configuration. Better yet, Authlogic tries to guess these names by checking for the existence of common names. If you checkout the Authlogic::ActsAsAuthentic submodules in the {documentation}[[http://authlogic.rubyforge.org]], it will show you the various names checked, chances are you won't have to specify any configuration for your field names, even if they aren't the same names as below.
 
@@ -108,6 +131,10 @@ One thing to note here is that this tries to take care of all the authentication
 This is where users will log in and out. It is responsible for managing their session. You create this controller JUST LIKE you do for any other model. The actions are exactly the same as well:
 
   $ script/generate controller user_sessions
+  
+For Rails 3 this would be:
+
+  $ rails generate controller user_sessions
 
 {Here is the source for the user_session_controller.rb}[http://github.com/binarylogic/authlogic_example/blob/5819a13477797d758cb6871f475ed1c54bf8a3a7/app/controllers/user_sessions_controller.rb].
 
@@ -122,6 +149,10 @@ Now just map your routes:
   # config/routes.rb
   map.resource :user_session
   map.root :controller => "user_sessions", :action => "new" # optional, this just sets the root route
+
+For Rails 3:
+
+  resource :user_session
 
 === 6. Persist sessions
 
@@ -146,6 +177,10 @@ Your application controller will be responsible for persisting your session. Thi
 
 That's it! You can name these methods anything you want. That's what's great about Authlogic, it doesn't assume things for you, you are in control of the application specific parts of authentication.
 
+In Rails 3, filter_parameter_logging in ActionController is deprecated and has no effect, so remove that line and set 'config.filter_parameters' in config/application.rb instead, like this:
+
+  config.filter_parameters += [:password, :password_confirmation]
+
 === 7. Restrict Access
 
 This is application specific. You can do this however you wish. For an example {see the ApplicationController}[http://github.com/binarylogic/authlogic_example/blob/5819a13477797d758cb6871f475ed1c54bf8a3a7/app/controllers/application_controller.rb] in the authlogic example app. Notice the require_user and require_no_user methods. They are enforced via before_filters in the other controllers. Restricting access is as simple as that. There are a million ways to do this, but this seems to be the most common and the simplest.
@@ -160,9 +195,18 @@ Add some routes:
   map.resource :account, :controller => "users"
   map.resources :users
 
+For Rails 3:
+
+  resource :account, :controller => 'users'
+  resources :users
+
 Create your UsersController:
 
-  script/generate controller users
+  $ script/generate controller users
+
+Or for Rails 3:
+
+  $ rails generate controller users
 
 {Here is the source for users_controller.rb}[http://github.com/binarylogic/authlogic_example/blob/5819a13477797d758cb6871f475ed1c54bf8a3a7/app/controllers/users_controller.rb].
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -21,4 +21,22 @@ class UserSessionsController < ApplicationController
     flash[:notice] = "Logout successful!"
     redirect_back_or_default new_user_session_url
   end
+  
+  private
+    def require_user 
+      unless current_user 
+        store_location 
+        flash[:notice] = "You must be logged in to access this page" 
+        redirect_to login_path 
+        return false 
+      end 
+    end 
+    def require_no_user 
+      if current_user 
+        store_location 
+        flash[:notice] = "You cannot access this page while logged in to another account" 
+        redirect_to root_url 
+        return false 
+      end 
+    end
 end


### PR DESCRIPTION
This is kind of an odd pull request because the instructions for Rails 3 that I added point to a fork of your project that added better Rails 3 support. I also admittedly did not update the actual app for Rails 3, just the instructions. However, I just thought you may or may not find this useful.

This commit you may want though, where I added the require_user and require_no_user methods to user_sessions_controller.rb: https://github.com/jonathandean/authlogic_example/commit/1aea9e23031dc007ab9188391a68154a8bf2580a

Thanks for an amazing gem, by the way. I love authlogic and it has made my life infinitely better while porting over a legacy PHP app to Rails :)
